### PR TITLE
Use GET parameters to support slashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.7"
+cache: pip
+install: "pip install -r requirements.txt"
+script: nosetests

--- a/polling_unit_lookup.py
+++ b/polling_unit_lookup.py
@@ -2,7 +2,7 @@ import os
 import re
 
 import requests
-from flask import Flask, jsonify
+from flask import Flask, request, jsonify
 
 
 # These are hardcoded here rather than being introduced into the database to
@@ -121,8 +121,9 @@ def get_area_from_pun(pun):
             return r.json()
 
 
-@app.route("/lookup/<polling_unit_number>")
-def lookup(polling_unit_number):
+@app.route("/")
+def lookup():
+    polling_unit_number = request.args.get('lookup')
     pun = tidy_up_pun(polling_unit_number)
 
     if not pun_re.search(pun):

--- a/polling_unit_lookup_test.py
+++ b/polling_unit_lookup_test.py
@@ -12,21 +12,21 @@ class PollingUnitLookupTestCase(unittest.TestCase):
         self.app = polling_unit_lookup.app.test_client()
 
     def test_polling_unit_lookup_invalid_number(self):
-        rv = self.app.get('/lookup/abcd')
+        rv = self.app.get('/?lookup=abcd')
         assert 'Unrecognized polling unit: abcd' in rv.data
         self.assertEqual(rv.status_code, 404)
 
     def test_polling_unit_lookup_valid_number(self):
         with requests_mock.mock() as m:
             m.get('http://pmo/code/poll_unit/AB:1:23:45', text='{"name": "Area"}')
-            rv = self.app.get('/lookup/AB:01:23:45')
+            rv = self.app.get('/?lookup=AB%3A01%3A23%3A45')
             self.assertEqual(rv.status_code, 200)
             self.assertEqual(rv.data, '{"name": "Area"}')
 
     def test_polling_unit_lookup_valid_number_no_area(self):
         with requests_mock.mock() as m:
             m.get('http://pmo/code/poll_unit/ZZ', status_code=404)
-            rv = self.app.get('/lookup/ZZ')
+            rv = self.app.get('/?lookup=ZZ')
             self.assertEqual(rv.status_code, 404)
             assert 'No areas were found that matched polling unit: ZZ' in rv.data
 
@@ -36,7 +36,14 @@ class PollingUnitLookupTestCase(unittest.TestCase):
             m.get('http://pmo/code/poll_unit/AB:1:23', status_code=404)
             m.get('http://pmo/code/poll_unit/AB:1', status_code=404)
             m.get('http://pmo/code/poll_unit/AB', text='{"name": "Area"}')
-            rv = self.app.get('/lookup/AB:01:23:45')
+            rv = self.app.get('/?lookup=AB%3A01%3A23%3A45')
+            self.assertEqual(rv.status_code, 200)
+            self.assertEqual(rv.data, '{"name": "Area"}')
+
+    def test_lookup_with_slashes(self):
+        with requests_mock.mock() as m:
+            m.get('http://pmo/code/poll_unit/AB:2:3:4', text='{"name": "Area"}')
+            rv = self.app.get('/?lookup=01%2F02%2F03%2F04')
             self.assertEqual(rv.status_code, 200)
             self.assertEqual(rv.data, '{"name": "Area"}')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ gunicorn==19.4.5
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
+nose==1.3.7
 requests-mock==0.7.0
 requests==2.9.1
 six==1.10.0


### PR DESCRIPTION
To ensure slashes aren't interpreted incorrectly we're switching to
using GET parameters for the PU number.

Fixes #1 
