### PR TITLE
Return more information in response

### DIFF
--- a/polling_unit_lookup.py
+++ b/polling_unit_lookup.py
@@ -116,7 +116,18 @@ def lookup():
         error = 'No areas were found that matched polling unit: {}'
         return jsonify(code=404, error=error.format(polling_unit_number)), 404
 
-    return jsonify(area)
+    fmt = '{mapit}/area/{area_id}/covered'
+    url = fmt.format(mapit=app.config['MAPIT_API_URL'], area_id=area['id'])
+    states = requests.get(url, params={'type': 'STA'}).json()
+    federal_constituencies = requests.get(url, params={'type': 'FED'}).json()
+    senatorial_districts = requests.get(url, params={'type': 'SEN'}).json()
+
+    return jsonify({
+        'area': area,
+        'states': states.values(),
+        'federal_constituencies': federal_constituencies.values(),
+        'senatorial_districts': senatorial_districts.values(),
+    })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As well as returning the MapIt area we now also return the State,
Federal Constituencies and Senatorial Districts in the response.

E.g. https://pu-lookup-pr-6.herokuapp.com/?lookup=AB:01:33:33 now returns:

``` json

{
  "area": {
    "all_names": {
      "gadm": [
        "GADM English Name", 
        "Aba North"
      ], 
      "poll_unit": [
        "The name given in the data set of Polling Unit Numbers", 
        "ABA NORTH"
      ]
    }, 
    "codes": {
      "poll_unit": "AB:1"
    }, 
    "country": "N", 
    "country_name": "Nigeria", 
    "generation_high": 1, 
    "generation_low": 1, 
    "id": 84, 
    "name": "Aba North", 
    "parent_area": 811, 
    "type": "LGA", 
    "type_name": "Local Government Area"
  }, 
  "federal_constituencies": [
    {
      "all_names": {}, 
      "codes": {}, 
      "country": "", 
      "country_name": "-", 
      "generation_high": 1, 
      "generation_low": 1, 
      "id": 1109, 
      "name": "Aba North/South", 
      "parent_area": null, 
      "type": "FED", 
      "type_name": "Federal Constituency"
    }
  ], 
  "senatorial_districts": [
    {
      "all_names": {}, 
      "codes": {}, 
      "country": "", 
      "country_name": "-", 
      "generation_high": 1, 
      "generation_low": 1, 
      "id": 811, 
      "name": "ABIA SOUTH", 
      "parent_area": 2, 
      "type": "SEN", 
      "type_name": "Senatorial District"
    }
  ], 
  "states": [
    {
      "all_names": {}, 
      "codes": {
        "poll_unit": "AB"
      }, 
      "country": "N", 
      "country_name": "Nigeria", 
      "generation_high": 1, 
      "generation_low": 1, 
      "id": 2, 
      "name": "Abia", 
      "parent_area": null, 
      "type": "STA", 
      "type_name": "State"
    }
  ]
}
```

Fixes #5 
