### PR TITLE
Return a 400 response for an invalid PU number

### DIFF
--- a/polling_unit_lookup.py
+++ b/polling_unit_lookup.py
@@ -107,8 +107,8 @@ def lookup():
     pun = tidy_up_pun(polling_unit_number)
 
     if not pun_re.search(pun):
-        error = 'Unrecognized polling unit: {}.'
-        return jsonify(code=404, error=error.format(polling_unit_number)), 404
+        error = 'Invalid polling unit: {}.'
+        return jsonify(code=400, error=error.format(polling_unit_number)), 400
 
     area = get_area_from_pun(pun)
 

--- a/polling_unit_lookup_test.py
+++ b/polling_unit_lookup_test.py
@@ -74,8 +74,8 @@ class PollingUnitLookupTestCase(unittest.TestCase):
 
     def test_polling_unit_lookup_invalid_number(self):
         rv = self.app.get('/?lookup=abcd')
-        self.assertIn('Unrecognized polling unit: abcd', rv.data)
-        self.assertEqual(rv.status_code, 404)
+        self.assertIn('Invalid polling unit: abcd', rv.data)
+        self.assertEqual(rv.status_code, 400)
 
     def test_polling_unit_lookup_valid_number(self):
         with requests_mock.mock() as m:


### PR DESCRIPTION
This allows the client to detect the difference between an invalid PU number and a valid PU number with no results.
