### PR TITLE
Change mapit url to point at standalone instance

### DIFF
--- a/polling_unit_lookup.py
+++ b/polling_unit_lookup.py
@@ -84,7 +84,7 @@ pun_re = re.compile('''
 
 app = Flask(__name__)
 app.config['MAPIT_API_URL'] = os.environ.get(
-    'MAPIT_API_URL', 'http://www.shineyoureye.org/mapit')
+    'MAPIT_API_URL', 'http://nigeria.mapit.mysociety.org')
 
 
 def mapit_url(pun):


### PR DESCRIPTION
There is now a standalone instance of mapit, so point at that instead of using the old site.
